### PR TITLE
Fix resource loading and driver path

### DIFF
--- a/src/test/java/helpers/ObjectRepository.java
+++ b/src/test/java/helpers/ObjectRepository.java
@@ -5,9 +5,10 @@ import java.io.InputStream;
 import java.util.Properties;
 public class ObjectRepository {
 	public static Properties OR = new Properties();
-	public static Properties ObjectRepo(String filepath) throws IOException {
-		InputStream in = new FileInputStream(filepath);
-		OR.load(in);
-		return OR;
-	}
+        public static Properties ObjectRepo(String filepath) throws IOException {
+                try (InputStream in = new FileInputStream(filepath)) {
+                        OR.load(in);
+                }
+                return OR;
+        }
 }

--- a/src/test/java/step_definitions/Hooks.java
+++ b/src/test/java/step_definitions/Hooks.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chrome.ChromeDriver;
+import java.nio.file.Paths;
 
 import cucumber.api.Scenario;
 import cucumber.api.java.After;
@@ -22,9 +23,16 @@ public class Hooks{
      * shared state between tests
      */
     public void openBrowser() throws MalformedURLException {
-    	System.out.println("Called openBrowser");
-    	System.setProperty("webdriver.chrome.driver","C:\\Users\\123\\workspace\\pallaviCucumber\\src\\test\\resources\\executables\\chromedriver.exe");
-    	driver = new ChromeDriver();
+        System.out.println("Called openBrowser");
+        String driverPath = Paths.get(
+                System.getProperty("user.dir"),
+                "src",
+                "test",
+                "resources",
+                "executables",
+                "chromedriver.exe").toString();
+        System.setProperty("webdriver.chrome.driver", driverPath);
+        driver = new ChromeDriver();
     	driver.manage().deleteAllCookies();
     	driver.manage().window().maximize();
     }


### PR DESCRIPTION
## Summary
- close the input stream when reading OR.properties
- compute chromedriver path relative to the project so tests can run on any workspace

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68887e8284f4832090697072d5eb93ed